### PR TITLE
Add window reference protection to allow SSR support

### DIFF
--- a/src/sdk/github.js
+++ b/src/sdk/github.js
@@ -12,7 +12,7 @@ let githubAppId
 let githubAuth
 
 // Load fetch polyfill for browsers not supporting fetch API
-if (!window.fetch) {
+if (typeof window !== 'undefined' && !window.fetch) {
   require('whatwg-fetch')
 }
 


### PR DESCRIPTION
This allows for a server side rendered app to import `react-social-login`.

This is merely a fix to avoid the following exception with node:
```
/react-social-login/dist/social-login.js:2077
if (!window.fetch) {
^

ReferenceError: window is not defined
```
This should have no impact on the browser, as `window` will always be defined.

It should fix #39 (although I have not tested with next.js) and avoid the suggested workaround of dynamically loading `react-social-login`, which makes the app and the module tightly coupled and adds complexity.