### PR TITLE
Fixed example Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,18 @@ Create the component of your choice and transform it into a SocialLogin componen
 import React from 'react'
 import SocialLogin from 'react-social-login'
 
-const Button = ({ children, triggerLogin, ...props }) => (
-  <button onClick={triggerLogin} {...props}>
-    { children }
-  </button>
-)
+class SocialButton extends React.Component {
 
-export default SocialLogin(Button)
+    render() {
+        return (
+            <button onClick={this.props.triggerLogin} {...this.props}>
+              { this.props.children }
+            </button>
+        );
+    }
+}
+
+export default SocialLogin(SocialButton);
 ```
 
 Then, use it like a normal component.


### PR DESCRIPTION
According to this issue ( https://github.com/deepakaggarwal7/react-social-login/issues/137 ) , using stateless components apps bootstrapped with create-react-app ^3.0.0 will break this component.
This can be easily fixed by extending React.Component.
Added the correct sample to Readme.MD