### PR TITLE
Change Google API URL

### DIFF
--- a/src/sdk/google.js
+++ b/src/sdk/google.js
@@ -11,7 +11,7 @@ const load = ({ appId, scope }) => new Promise((resolve, reject) => {
   const firstJS = document.getElementsByTagName('script')[0]
   const js = document.createElement('script')
 
-  js.src = 'https://apis.google.com/js/platform.js'
+  js.src = 'https://apis.google.com/js/api.js'
   js.id = 'gapi-client'
 
   js.onload = () => {
@@ -138,7 +138,7 @@ const generateUser = (response) => {
 const oldLoad = (appId, cid, fn, err) => {
   const js = document.createElement('script')
 
-  js.src = 'https://apis.google.com/js/platform.js'
+  js.src = 'https://apis.google.com/js/api.js'
   js.id = 'gapi-client'
 
   js.onload = () => {


### PR DESCRIPTION
Unfortunately, the URL https://apis.google.com/js/platform.js contains user tracking code and is therefore blocked by ad blockers when the "Block social media icons tracking" option is enabled. When this happens, the Google sign in button will not be shown. However, the URL https://apis.google.com/js/api.js is not blocked by ad blockers and works the same for social login. This is also the URL used by [react-google-login](https://github.com/anthonyjgrove/react-google-login/blob/master/src/use-google-login.js), so I would suggest you do the same.